### PR TITLE
Exclude text widget editor

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -246,7 +246,7 @@
             edButtons[1] = new edButton('ed_em','i','<i>','</i>','i');
         }
 
-        $('body').bind('afterPreWpautop', function(e, o) {
+        $('body:not(.widgets-php)').bind('afterPreWpautop', function(e, o) {
             //On Switch to HTML & On save/update from Visual tab
             //Now we replace all those temporary html comments with spaces and newlines
             o.data = o.unfiltered;


### PR DESCRIPTION
If you enter two or more paragraphs in visual mode, it adds a linebreak after the closing `</p>` tags, instead of writing everything in one line. This repeats when switching between the visual and text tab, and the so generated empty lines get converted into `<p>&nbsp;</p>`. As the text widget shouldn't be used for complex markup, it's better to remove the plugins functionality here (on the customizer screen it doesn't apply anyway).